### PR TITLE
Use `permitted_classes` and `aliases` for Ruby 3.1+ and drop support ruby < 2.6 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,6 @@ on:
   schedule:
     - cron: "0 10 * * 5" # JST 19:00 (Fri)
 
-env:
-  CI: "true"
-
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-
       - name: Cache vendor/bundle
         uses: actions/cache@v1
         id: cache_gem

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,6 @@ jobs:
 
       matrix:
         ruby:
-          - ruby:2.1
-          - ruby:2.2
-          - ruby:2.3
-          - ruby:2.4
-          - ruby:2.5
           - ruby:2.6
           - ruby:2.7
           - ruby:3.0

--- a/lib/sengiri_yaml.rb
+++ b/lib/sengiri_yaml.rb
@@ -7,7 +7,7 @@ module SengiriYaml
 
   # load divided yaml files
   # @see SengiriYaml::Loader#load_dir
-  def load_dir(src_dir)
-    SengiriYaml::Loader.new.load_dir(src_dir)
+  def load_dir(src_dir, permitted_classes: [], aliases: false)
+    SengiriYaml::Loader.new.load_dir(src_dir, permitted_classes: permitted_classes, aliases: aliases)
   end
 end

--- a/lib/sengiri_yaml/loader.rb
+++ b/lib/sengiri_yaml/loader.rb
@@ -6,7 +6,7 @@ module SengiriYaml
     # load divided yaml files
     # @param src_dir [String] divided yaml dir
     # @return [Hash] merged yaml hash
-    def load_dir(src_dir)
+    def load_dir(src_dir, permitted_classes: [], aliases: false)
       merged_content = ""
 
       Pathname.glob("#{src_dir}/*.yml").sort.each do |yaml_path|
@@ -14,7 +14,7 @@ module SengiriYaml
         merged_content << content
       end
 
-      YAML.load(merged_content)
+      YAML.safe_load(merged_content, permitted_classes: permitted_classes, aliases: aliases)
     end
   end
 end

--- a/sengiri_yaml.gemspec
+++ b/sengiri_yaml.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/sue445/sengiri_yaml"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = ">= 2.6"
+
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"


### PR DESCRIPTION
c.f.

* https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/
* https://bugs.ruby-lang.org/issues/17866

# NOTE
`permitted_classes` is available Psych 3.1.0+ (and Ruby 2.6.0+)

https://github.com/ruby/psych/commit/682abf20f0ddbc8d83e816022953536dad80c05b

And Ruby 2.5 is already EOL
https://www.ruby-lang.org/en/downloads/branches/

So I drop support Ruby < 2.6

```
$ ruby -v
ruby 2.6.0p0 (2018-12-25 revision 66547) [x86_64-linux]
$ gem list | grep psych
psych (default: 3.1.0)
```